### PR TITLE
stopping input when pressing jailbreak button

### DIFF
--- a/src/download0/main-menu.ts
+++ b/src/download0/main-menu.ts
@@ -302,7 +302,7 @@ import { fn, BigInt } from 'download0/types'
       const selectedOption = menuOptions[currentButton]
       if (!selectedOption) return
       if (selectedOption.script === 'loader.js') {
-        jsmaf.onKeyDown = function () {}; 
+        jsmaf.onKeyDown = function () {}
       }
       log('Loading ' + selectedOption.script + '...')
       try {


### PR DESCRIPTION
```
[17:48:01.251] [*] Cleaning up...
[17:48:01.251] [*] Restoring to previous core: 5
[17:48:01.252] [*] Cleanup completed
[17:48:01.252] [+] Initializing binloader...
[17:48:01.253] [+] binloader_init(): Initializing binloader...
[17:48:01.254] [+] binloader_init(): Dependencies OK, initializing...
[17:48:01.255] [+] thrd_create @ 0x000000010C8295A0
[17:48:01.255] [+] thrd_join @ 0x000000010C829410
[17:48:01.256] [+] === PS4 Payload Loader ===
[17:48:01.256] [+] Checking: /mnt/usb0/payload.bin
[17:48:01.257] [+]   stat() failed - file not found
[17:48:01.258] [+] Checking: /mnt/usb1/payload.bin
[17:48:01.258] [+]   stat() failed - file not found
[17:48:01.259] [+] Checking: /mnt/usb2/payload.bin
[17:48:01.259] [+]   stat() failed - file not found
[17:48:01.260] [+] Checking: /mnt/usb3/payload.bin
[17:48:01.260] [+]   stat() failed - file not found
[17:48:01.284] [+] Checking: /mnt/usb4/payload.bin
[17:48:01.286] [+]   stat() failed - file not found
[17:48:01.288] [+] Checking: /data/payload.bin
[17:48:01.290] [+]   Found: 290592 bytes
[17:48:01.292] [+] Found cached payload: /data/payload.bin (290592 bytes)
[17:48:01.294] [+] Loading payload from: /data/payload.bin
[17:48:01.296] [+] Read 290592 bytes
[17:48:01.298] [+] mmap() allocated at: 0x0000000226200000
[17:48:01.300] [+] Non-ELF binary, treating as raw shellcode (290592 bytes)
[17:48:01.650] [+] Entry point: 0x0000000226200000
[17:48:01.651] [+] Spawning payload thread using thrd_create...
[17:48:01.652] [+] Entry point @ 0x0000000226200000
[17:48:01.652] [+] Calling thrd_create...
[17:48:01.786] [+] SUCCESS: Payload thread created!
[17:48:01.787] [+] Thread handle: 0x00000008814A07C0
[17:48:01.787] [+] Waiting for thread to complete (thrd_join)...
[17:48:02.330] [+] Thread completed successfully with result: 0
[17:48:02.330] [+] Binloader complete - thread has finished
[17:48:02.331] [+] Payload loaded successfully
[17:48:02.332] [+] Binloader initialized and running!
[17:48:03.265] [+] Logging Success...
[17:48:03.266] [+] [STATS] Success incremented to: 2
[17:48:03.266] [+] UID before setuid: 0
[17:48:03.267] [+] Attempting setuid(0)...
[17:48:03.267] [+] setuid returned: 0
[17:48:03.268] [+] UID after setuid: 0
[17:48:03.268] [+] Already jailbroken
[17:48:03.269] [+] [STATS] Saved: total=3, success=2
[17:48:18.395] [+] Loading loader.js...
[17:48:18.396] [+] ERROR loading loader.js: Failed to include file: loader.js
[17:48:18.398] [+] include@[native code]
include
handleButtonPress@main-menu.js:293:16
onKeyDown@main-menu.js:308:24
[17:48:24.366] [*] Disconnected
```
this will prevent users from pressing jailbreak button twice
