### PR TITLE
Fix bgm music config in loader

### DIFF
--- a/src/download0/loader.ts
+++ b/src/download0/loader.ts
@@ -32,9 +32,11 @@ export function show_success () {
   }, 2000)
 }
 
-const audio = new jsmaf.AudioClip()
-audio.volume = 0.5  // 50% volume
-audio.open('file://../download0/sfx/bgm.wav')
+if (typeof CONFIG !== 'undefined' && CONFIG.music) {
+  const audio = new jsmaf.AudioClip()
+  audio.volume = 0.5  // 50% volume
+  audio.open('file://../download0/sfx/bgm.wav')
+}
 
 const is_jailbroken = checkJailbroken()
 


### PR DESCRIPTION
This change will fix bgm music config being not loaded in loader on JB process (after clicking the Jailbreak)