### PR TITLE
fix(netctrl): align triple free loop failure check with iteration limit

### DIFF
--- a/src/download0/netctrl_c0w_twins.ts
+++ b/src/download0/netctrl_c0w_twins.ts
@@ -1402,7 +1402,7 @@ function trigger_ucred_triplefree () {
       count++
     }
 
-    if (count === 1000) {
+    if (count === 10000) {
       log('Dropped out from reclaim loop')
       // Clean up and start again
       close(new BigInt(uaf_socket))


### PR DESCRIPTION
The `trigger_ucred_triplefree` function allows the reclaim loop to run for 10,000 iterations, but the failure check incorrectly tested against 1,000. This mismatch caused the exploit to proceed with an invalid state when the race condition was missed, leading to stability issues and crashes.

This change updates the failure condition to `count === 10000` to correctly detect loop exhaustion and trigger the retry/cleanup logic.