### PR TITLE
Use release tag for debug version info

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Replace version string with commit hash
-        run: find ./dist -type f -name '*.js' -exec sed -i "s/%VERSION_STRING%/${{ github.sha }}/g" {} +
+      - name: Replace version string with release tag
+        run: find ./dist -type f -name '*.js' -exec sed -i "s/%VERSION_STRING%/${{ github.ref_name }}/g" {} +
 
       - name: Copy assets to dist
         run: |


### PR DESCRIPTION
This change updates the version debug information in the `netctrl` exploit to use the release tag instead of the commit SHA, making it more human-readable simpler to understand