### PR TITLE
Add Latin American Spanish (es-419) locale support

### DIFF
--- a/src/download0/languages.ts
+++ b/src/download0/languages.ts
@@ -36,6 +36,11 @@ if (IMAGE_TEXT_LOCALES.includes(detectedLocale)) {
 
 switch (detectedLocale) {
   case 'es':
+  case 'es-ES':
+  case 'es-CL':
+  case 'es-419':
+  case 'es-MX':
+  case 'es-AR':
     // Spanish
     lang.jailbreak = 'Jailbreak'
     lang.payloadMenu = 'Menu de Payloads'


### PR DESCRIPTION
Update languages.ts
feat: add Latin American Spanish locale (es-419, es-MX, es-AR, es-CL, es-CO)