### PR TITLE
feat(loader): fallback to poops when lapse is forced on FW > 12.02

### DIFF
--- a/src/download0/loader.ts
+++ b/src/download0/loader.ts
@@ -114,9 +114,15 @@ if (!is_jailbroken) {
     log('JB Behavior: NetControl (forced)')
     include('netctrl_c0w_twins.js')
   } else if (jb_behavior === 2) {
-    log('JB Behavior: Lapse (forced)')
-    use_lapse = true
-    lapse()
+    // Check if system is newer than 12.02 and load poops (netctrl) instead
+    if (compare_version(FW_VERSION, '12.02') > 0) {
+      log('JB Behavior: Lapse forced but FW > 12.02, using Poops instead')
+      include('netctrl_c0w_twins.js')
+    } else {
+      log('JB Behavior: Lapse (forced)')
+      use_lapse = true
+      lapse()
+    }
   } else {
     log('JB Behavior: Auto Detect')
     if (compare_version(FW_VERSION, '7.00') >= 0 && compare_version(FW_VERSION, '12.02') <= 0) {


### PR DESCRIPTION
This PR adds a check in `loader.ts` to ensure that if a user has manually selected lapse but their firmware version is higher than 12.02, the loader will automatically use poops (NetControl) instead. This is useful for users who updated their firmware but didn't update their configuration.