### PR TITLE
netctrl: outer auto-retry on clean failure + tunable spray constants via config.json

### DIFF
--- a/src/download0/config.json
+++ b/src/download0/config.json
@@ -6,7 +6,8 @@
         "autoclose_delay": 3000,
         "music": true,
         "jb_behavior": 0,
-        "theme": "default"
+        "theme": "default",
+        "jb_retries": 3
     },
     "payloads": []
 }

--- a/src/download0/netctrl_c0w_twins.ts
+++ b/src/download0/netctrl_c0w_twins.ts
@@ -139,12 +139,29 @@ const MSG_IOV_NUM = 0x17
 const IPV6_SOCK_NUM = 96
 const IOV_THREAD_NUM = 8
 const UIO_THREAD_NUM = 8
-const MAIN_LOOP_ITERATIONS = 3
-const TRIPLEFREE_ITERATIONS = 8
-const KQUEUE_ITERATIONS = 5000
 
-const MAX_ROUNDS_TWIN = 5
-const MAX_ROUNDS_TRIPLET = 200
+// Tunables: overridable via config.json (CONFIG.*), defaults preserved
+function cfg_num (key: string, def: number): number {
+  // CONFIG is injected by the host from download0/config.json
+  if (typeof CONFIG !== 'undefined' && typeof (CONFIG as Record<string, unknown>)[key] === 'number') {
+    const v = Number((CONFIG as Record<string, unknown>)[key])
+    if (v > 0) return v
+  }
+  return def
+}
+
+const MAIN_LOOP_ITERATIONS = cfg_num('main_loop_iterations', 3)
+const TRIPLEFREE_ITERATIONS = cfg_num('triplefree_iterations', 8)
+const KQUEUE_ITERATIONS = cfg_num('kqueue_iterations', 5000)
+
+const MAX_ROUNDS_TWIN = cfg_num('max_rounds_twin', 5)
+const MAX_ROUNDS_TRIPLET = cfg_num('max_rounds_triplet', 200)
+
+// Outer auto-retry: on clean failure ("Failed to acquire kernel R/W") restart
+// the whole exploit chain in-process instead of forcing a manual app relaunch.
+const JB_RETRIES_DEFAULT = 3
+const JB_RETRY_DELAY_MS = 2000
+let outer_retry = 0
 
 const MAIN_CORE = 4
 const MAIN_RTPRIO = 0x100
@@ -994,6 +1011,7 @@ let exploit_count = 0
 let exploit_end = false
 
 function netctrl_exploit () {
+  outer_retry = 0
   setup_log_screen()
 
   const supported_fw = init()
@@ -1016,6 +1034,20 @@ function exploit_phase_setup () {
 function exploit_phase_trigger () {
   if (exploit_count >= MAIN_LOOP_ITERATIONS) {
     log('Failed to acquire kernel R/W')
+    // Clean failure: heap state is still sane, so instead of giving up and
+    // forcing a manual app relaunch, restart the whole chain in-process.
+    const max_outer = (typeof CONFIG !== 'undefined' && typeof CONFIG.jb_retries === 'number') ? CONFIG.jb_retries : JB_RETRIES_DEFAULT
+    if (outer_retry < max_outer) {
+      outer_retry++
+      log('Auto-retry ' + outer_retry + '/' + max_outer + ': rebuilding workers in ' + (JB_RETRY_DELAY_MS / 1000) + 's...')
+      cleanup(true) // kill leftover workers so setup() can recreate them
+      cleanup_called = false // allow cleanup to run again on the next attempt
+      setTimeout(function () {
+        yield_to_render(exploit_phase_setup)
+      }, JB_RETRY_DELAY_MS)
+      return
+    }
+    log('Auto-retry budget exhausted (' + max_outer + '). Give up.')
     cleanup()
     return
   }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -34,6 +34,14 @@ declare var CONFIG: {
   autolapse?: boolean;
   autopoop?: boolean;
   autoclose?: boolean;
+  autoclose_delay?: number;
+  jb_behavior?: number;
+  jb_retries?: number;
+  main_loop_iterations?: number;
+  triplefree_iterations?: number;
+  kqueue_iterations?: number;
+  max_rounds_twin?: number;
+  max_rounds_triplet?: number;
   music?: boolean;
 } | undefined
 


### PR DESCRIPTION
﻿## What

Two stability improvements for the NetCtrl path (FW 12.5x), where users currently need many manual app relaunches to jailbreak.

### 1. Outer auto-retry on clean failure
When the phase machine exhausts `MAIN_LOOP_ITERATIONS` without getting kernel R/W, the app now restarts the whole chain in-process (up to `CONFIG.jb_retries`, default 3) instead of silently giving up:
- `cleanup(true)` kills leftover ROP workers so `setup()` can recreate them
- `cleanup_called` is reset so cleanup can run again on the next attempt
- a 2s delay lets sockets/threads settle before restarting from `exploit_phase_setup`

Hard failures (thrown errors such as `Netctrl failed - Shutdown and try again`) still abort immediately, since those indicate corrupted kernel state that an in-process retry cannot fix. This change only converts the *clean* failure case - which today costs a full app kill + relaunch - into an automatic retry.

### 2. Tunable spray constants
`MAIN_LOOP_ITERATIONS`, `TRIPLEFREE_ITERATIONS`, `KQUEUE_ITERATIONS`, `MAX_ROUNDS_TWIN` and `MAX_ROUNDS_TRIPLET` are now overridable via `config.json` (`main_loop_iterations`, `triplefree_iterations`, `kqueue_iterations`, `max_rounds_twin`, `max_rounds_triplet`). Defaults are unchanged, so behavior is identical for existing configs. This lets users with problematic consoles tune attempts per run without rebuilding.

## Testing
- `npm run build` compiles cleanly (babel, 20 files)
- Logic verified by inspection against `cleanup()`/`create_workers()`/`setup()`: worker arrays are assigned by index (no duplication on re-setup) and `ipv6_socks` is a fixed-size array refilled in place
